### PR TITLE
feat: Support Rename and Edit Static Files (halo #573)

### DIFF
--- a/src/api/static.js
+++ b/src/api/static.js
@@ -46,4 +46,15 @@ staticApi.upload = (formData, uploadProgress, cancelToken, basePath) => {
   })
 }
 
+staticApi.rename = (basePath, newName) => {
+  return service({
+    url: `${baseUrl}/rename`,
+    params: {
+      basePath: basePath,
+      newName: newName
+    },
+    method: 'post'
+  })
+}
+
 export default staticApi

--- a/src/api/static.js
+++ b/src/api/static.js
@@ -64,11 +64,11 @@ staticApi.getContent = url => {
   })
 }
 
-staticApi.save = (basePath, content) => {
+staticApi.save = (path, content) => {
   return service({
-    url: `${baseUrl}/save`,
+    url: `${baseUrl}/files`,
     data: {
-      basePath: basePath,
+      path: path,
       content: content
     },
     method: 'put'

--- a/src/api/static.js
+++ b/src/api/static.js
@@ -57,4 +57,22 @@ staticApi.rename = (basePath, newName) => {
   })
 }
 
+staticApi.getContent = url => {
+  return service({
+    url: `${url}`,
+    method: 'get'
+  })
+}
+
+staticApi.save = (basePath, content) => {
+  return service({
+    url: `${baseUrl}/save`,
+    data: {
+      basePath: basePath,
+      content: content
+    },
+    method: 'put'
+  })
+}
+
 export default staticApi

--- a/src/views/system/developer/tabs/StaticStorage.vue
+++ b/src/views/system/developer/tabs/StaticStorage.vue
@@ -214,7 +214,6 @@ import { mapGetters } from 'vuex'
 import staticApi from '@/api/static'
 import { codemirror } from 'vue-codemirror-lite'
 const context = require.context('codemirror/mode', true, /\.js$/)
-console.log(context)
 context.keys().map(context)
 const columns = [
   {

--- a/src/views/system/staticpages/tabs/StaticPagesList.vue
+++ b/src/views/system/staticpages/tabs/StaticPagesList.vue
@@ -41,7 +41,7 @@
             slot-scope="name"
           >
             <ellipsis
-              :length="64"
+              :length=64
               tooltip
             >
               {{ name }}

--- a/src/views/system/staticpages/tabs/StaticPagesList.vue
+++ b/src/views/system/staticpages/tabs/StaticPagesList.vue
@@ -41,7 +41,7 @@
             slot-scope="name"
           >
             <ellipsis
-              :length=64
+              :length="64"
               tooltip
             >
               {{ name }}


### PR DESCRIPTION
1. 支持静态文件的重命名和编辑，编辑器能够根据文件后缀改变语法高亮
2. 编辑的模态框只能通过Popconfirm退出，防止未保存的内容丢失
3. 模态框Input自动focus
4. StaticStorage.vue的`length="64"`改为`:length="64"`