### PR TITLE
feat: Enhance the function of post management (halo #733)

### DIFF
--- a/src/api/category.js
+++ b/src/api/category.js
@@ -60,7 +60,8 @@ function concreteTree(parentCategory, categories) {
       parentCategory.children.push({
         key: category.id,
         title: category.name,
-        isLeaf: false
+        isLeaf: false,
+        value: category.name
       })
     }
   })

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -76,6 +76,22 @@ postApi.updateStatusInBatch = (ids, status) => {
   })
 }
 
+postApi.updateDisallowCommentInBatch = (ids, disallowComment) => {
+  return service({
+    url: `${baseUrl}/disallow_comment/${disallowComment}`,
+    data: ids,
+    method: 'put'
+  })
+}
+
+postApi.updateTopPriorityInBatch = (ids, topPriority) => {
+  return service({
+    url: `${baseUrl}/top_priority/${topPriority}`,
+    data: ids,
+    method: 'put'
+  })
+}
+
 postApi.delete = postId => {
   return service({
     url: `${baseUrl}/${postId}`,

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -32,8 +32,10 @@ postApi.get = postId => {
 postApi.getPosts = postIds => {
   return service({
     url: `${baseUrl}/posts`,
-    method: 'post',
-    data: postIds
+    method: 'get',
+    params: {
+      ids: postIds + ''
+    }
   })
 }
 

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -29,6 +29,14 @@ postApi.get = postId => {
   })
 }
 
+postApi.getPosts = postIds => {
+  return service({
+    url: `${baseUrl}/posts`,
+    method: 'post',
+    data: postIds
+  })
+}
+
 postApi.create = (postToCreate, autoSave) => {
   return service({
     url: baseUrl,
@@ -88,6 +96,14 @@ postApi.updateTopPriorityInBatch = (ids, topPriority) => {
   return service({
     url: `${baseUrl}/top_priority/${topPriority}`,
     data: ids,
+    method: 'put'
+  })
+}
+
+postApi.updataSettingInBatch = settingParams => {
+  return service({
+    url: `${baseUrl}/setting`,
+    data: settingParams,
     method: 'put'
   })
 }

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -24,9 +24,9 @@
             >
               <a-form-item label="文章状态：">
                 <a-select
-                  v-model="queryParam.status"
+                  v-model="selectStatus"
                   placeholder="请选择文章状态"
-                  @change="handleQuery()"
+                  @change="onStatusSelectChange"
                 >
                   <a-select-option
                     v-for="status in Object.keys(postStatus)"
@@ -578,7 +578,7 @@ export default {
   mixins: [mixin, mixinDevice],
   data() {
     return {
-      postStatus: postApi.postStatus,
+      postStatus: Object.assign({}, { ALL: { text: '所有文章' } }, postApi.postStatus),
       pagination: {
         page: 1,
         size: 10,
@@ -610,7 +610,8 @@ export default {
       selectedPost: {},
       selectedTagIds: [],
       selectedCategoryIds: [],
-      treeSelectValue: undefined
+      treeSelectValue: '所有分类',
+      selectStatus: 'ALL'
     }
   },
   computed: {
@@ -621,7 +622,13 @@ export default {
       })
     },
     categoryTree() {
-      return categoryApi.concreteTree(this.categories)
+      const tree = categoryApi.concreteTree(this.categories)
+      return [{
+        key: 0,
+        title: '所有分类',
+        value: '所有分类',
+        children: tree
+      }]
     }
   },
   created() {
@@ -704,6 +711,8 @@ export default {
       this.queryParam.keyword = null
       this.queryParam.categoryId = null
       this.queryParam.status = null
+      this.selectStatus = 'ALL'
+      this.treeSelectValue = '所有分类'
       this.handleClearRowKeys()
       this.handlePaginationChange(1, this.pagination.size)
     },
@@ -796,8 +805,16 @@ export default {
       this.selectedMetas = metas
     },
     onTreeSelectChange(value) {
-      let id = this.categories.filter(category => category.name == value)[0].id
-      this.queryParam.categoryId = id
+      if (value === '所有分类') {
+        this.queryParam.categoryId = null
+      } else {
+        const id = this.categories.filter(category => category.name === value)[0].id
+        this.queryParam.categoryId = id
+      }
+      this.handleQuery()
+    },
+    onStatusSelectChange(value) {
+      this.queryParam.status = value === 'ALL' ? null : value
       this.handleQuery()
     }
   }

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -898,7 +898,6 @@ export default {
     },
     onBatchOperationClose() {
       this.batchOperationVisible = false
-      this.selectedPost = {}
       setTimeout(() => {
         this.loadPosts()
       }, 500)

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -184,7 +184,7 @@
                   href="javascript:void(0);"
                   @click="handleShowBatchOperation"
                 >
-                  <span>其他操作</span>
+                  <span>更多操作</span>
                 </a>
               </a-popover>
             </a-menu-item>
@@ -570,7 +570,8 @@
     />
 
     <BatchOperationDrawer
-      :postIds="selectedPostIds"
+      :posts="selectedPosts"
+      :postIds="selectedRowKeys"
       :visible="batchOperationVisible"
       @close="onBatchOperationClose"
     />
@@ -680,9 +681,9 @@ export default {
       selectedPost: {},
       selectedTagIds: [],
       selectedCategoryIds: [],
-      selectedPostIds: [],
       treeSelectValue: '所有分类',
-      selectStatus: 'ALL'
+      selectStatus: 'ALL',
+      selectedPosts: [],
     }
   },
   computed: {
@@ -863,7 +864,14 @@ export default {
       })
     },
     handleShowBatchOperation() {
-      this.batchOperationVisible = true
+      if (this.selectedRowKeys.length <= 0) {
+        this.$message.info('请至少选择一项！')
+        return
+      }
+      postApi.getPosts(this.selectedRowKeys).then(response => {
+        this.selectedPosts = response.data.data
+        this.batchOperationVisible = true
+      })
     },
     handlePreview(postId) {
       postApi.preview(postId).then(response => {

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -41,16 +41,15 @@
               :sm="24"
             >
               <a-form-item label="分类目录：">
-                <a-select
-                  v-model="queryParam.categoryId"
+                <a-tree-select
+                  v-model="treeSelectValue"
+                  style="width: 100%"
+                  :dropdown-style="{ maxHeight: '400px', overflow: 'auto' }"
+                  :tree-data="categoryTree"
                   placeholder="请选择分类"
-                  @change="handleQuery()"
-                >
-                  <a-select-option
-                    v-for="category in categories"
-                    :key="category.id"
-                  >{{ category.name }} ({{ category.postCount }})</a-select-option>
-                </a-select>
+                  tree-default-expand-all
+                  @change="onTreeSelectChange"
+                />
               </a-form-item>
             </a-col>
 
@@ -610,7 +609,8 @@ export default {
       postCommentVisible: false,
       selectedPost: {},
       selectedTagIds: [],
-      selectedCategoryIds: []
+      selectedCategoryIds: [],
+      treeSelectValue: undefined
     }
   },
   computed: {
@@ -619,6 +619,9 @@ export default {
         post.statusProperty = this.postStatus[post.status]
         return post
       })
+    },
+    categoryTree() {
+      return categoryApi.concreteTree(this.categories)
     }
   },
   created() {
@@ -791,6 +794,11 @@ export default {
     },
     onRefreshPostMetasFromSetting(metas) {
       this.selectedMetas = metas
+    },
+    onTreeSelectChange(value) {
+      let id = this.categories.filter(category => category.name == value)[0].id
+      this.queryParam.categoryId = id
+      this.handleQuery()
     }
   }
 }

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -648,6 +648,7 @@ export default {
   mixins: [mixin, mixinDevice],
   data() {
     return {
+      // unshift an option of all post
       postStatus: Object.assign({}, { ALL: { text: '所有文章' } }, postApi.postStatus),
       pagination: {
         page: 1,
@@ -695,6 +696,7 @@ export default {
     },
     categoryTree() {
       const tree = categoryApi.concreteTree(this.categories)
+      // insert a parent node of all category
       return [{
         key: 0,
         title: '所有分类',

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -100,7 +100,7 @@
                 href="javascript:void(0);"
                 @click="handleEditStatusMore(postStatus.RECYCLE.value)"
               >
-                <span>移到回收站</span>
+                <span>移入回收站</span>
               </a>
             </a-menu-item>
             <a-menu-item
@@ -811,6 +811,17 @@ export default {
       }
       postApi.updateStatusInBatch(this.selectedRowKeys, status).then(response => {
         this.$log.debug(`postId: ${this.selectedRowKeys}, status: ${status}`)
+        switch (status) {
+          case postApi.postStatus.PUBLISHED.value:
+            this.$message.success('发布成功！')
+            break;
+          case postApi.postStatus.DRAFT.value:
+            this.$message.success('设置草稿成功！')
+            break;
+          case postApi.postStatus.RECYCLE.value:
+            this.$message.success('移入回收站成功！')
+            break;
+        }
         this.selectedRowKeys = []
         this.loadPosts()
       })
@@ -823,6 +834,7 @@ export default {
       postApi.deleteInBatch(this.selectedRowKeys).then(response => {
         this.$log.debug(`delete: ${this.selectedRowKeys}`)
         this.selectedRowKeys = []
+        this.$message.success('永久删除成功！')
         this.loadPosts()
       })
     },
@@ -834,6 +846,11 @@ export default {
       postApi.updateDisallowCommentInBatch(this.selectedRowKeys, disallowComment).then(response => {
         this.$log.debug(`postId: ${this.selectedRowKeys}, disallowComment: ${disallowComment}`)
         this.selectedRowKeys = []
+        if (disallowComment) {
+          this.$message.success('关闭评论成功！')
+        } else {
+          this.$message.success('开启评论成功！')
+        }
         this.loadPosts()
       })
     },
@@ -845,6 +862,11 @@ export default {
       postApi.updateTopPriorityInBatch(this.selectedRowKeys, topPriority).then(response => {
         this.$log.debug(`postId: ${this.selectedRowKeys}, topPriority: ${topPriority}`)
         this.selectedRowKeys = []
+        if (topPriority === 1) {
+          this.$message.success('置顶成功！')
+        } else {
+          this.$message.success('取消置顶成功！')
+        }
         this.loadPosts()
       })
     },

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -684,7 +684,7 @@ export default {
       selectedCategoryIds: [],
       treeSelectValue: '所有分类',
       selectStatus: 'ALL',
-      selectedPosts: [],
+      selectedPosts: []
     }
   },
   computed: {
@@ -816,13 +816,13 @@ export default {
         switch (status) {
           case postApi.postStatus.PUBLISHED.value:
             this.$message.success('发布成功！')
-            break;
+            break
           case postApi.postStatus.DRAFT.value:
             this.$message.success('设置草稿成功！')
-            break;
+            break
           case postApi.postStatus.RECYCLE.value:
             this.$message.success('移入回收站成功！')
-            break;
+            break
         }
         this.selectedRowKeys = []
         this.loadPosts()

--- a/src/views/post/components/BatchOperationDrawer.vue
+++ b/src/views/post/components/BatchOperationDrawer.vue
@@ -1,0 +1,211 @@
+<template>
+  <a-drawer
+    title="批量操作"
+    :width="isMobile()?'100%':'480'"
+    placement="right"
+    closable
+    destroyOnClose
+    @close="onClose"
+    :visible="visible"
+  >
+    <a-skeleton
+      active
+      :loading="settingLoading"
+      :paragraph="{ rows: 24 }"
+    >
+      <div class="post-setting-drawer-content">
+        <div :style="{ marginBottom: '16px' }">
+          <h3 class="post-setting-drawer-title">基本设置</h3>
+          <br>
+          <div class="post-setting-drawer-item">
+            <a-form layout="vertical">
+              <a-form-item label="开启评论：">
+                <a-radio-group
+                  v-model="disallowComment"
+                  :defaultValue="null"
+                >
+                  <a-radio :value="null">不改变</a-radio>
+                  <a-radio :value="false">开启</a-radio>
+                  <a-radio :value="true">关闭</a-radio>
+                </a-radio-group>
+              </a-form-item>
+              <a-form-item label="是否置顶：">
+                <a-radio-group
+                  v-model="topPriority"
+                  :defaultValue="null"
+                >
+                  <a-radio :value="null">不改变</a-radio>
+                  <a-radio :value="1">是</a-radio>
+                  <a-radio :value="0">否</a-radio>
+                </a-radio-group>
+              </a-form-item>
+            </a-form>
+          </div>
+        </div>
+        <a-divider />
+
+        <div :style="{ marginBottom: '16px' }">
+          <h3 class="post-setting-drawer-title">分类目录</h3>
+          <div class="post-setting-drawer-item">
+            <a-form layout="vertical">
+              <a-form-item>
+                <category-tree
+                  v-model="selectedCategoryIds"
+                  :categories="categories"
+                />
+              </a-form-item>
+              <a-form-item v-if="categoryFormVisible">
+                <category-select-tree
+                  :categories="categories"
+                />
+              </a-form-item>
+              <a-form-item v-if="categoryFormVisible">
+                <a-input
+                  placeholder="分类名称"
+                />
+              </a-form-item>
+              <a-form-item v-if="categoryFormVisible">
+                <a-input
+                  placeholder="分类路径"
+                />
+              </a-form-item>
+              <a-form-item>
+                <a-button
+                  type="primary"
+                  style="marginRight: 8px"
+                  v-if="categoryFormVisible"
+                  @click="handlerCreateCategory"
+                >保存</a-button>
+                <a-button
+                  type="dashed"
+                  style="marginRight: 8px"
+                  v-if="!categoryFormVisible"
+                  @click="toggleCategoryForm"
+                >新增</a-button>
+                <a-button
+                  v-if="categoryFormVisible"
+                  @click="toggleCategoryForm"
+                >取消</a-button>
+              </a-form-item>
+            </a-form>
+          </div>
+        </div>
+        <a-divider />
+
+        <div :style="{ marginBottom: '16px' }">
+          <h3 class="post-setting-drawer-title">标签</h3>
+          <div class="post-setting-drawer-item">
+            <a-form layout="vertical">
+              <a-form-item>
+                <TagSelect v-model="selectedTagIds" />
+              </a-form-item>
+            </a-form>
+          </div>
+        </div>
+        <a-divider />
+
+        <a-divider class="divider-transparent" />
+      </div>
+    </a-skeleton>
+
+    <div class="bottom-control">
+      <a-button
+        type="primary"
+        :loading="saving"
+        @click="handleSaveSettings"
+      >保存</a-button>
+    </div>
+  </a-drawer>
+</template>
+<script>
+import { mixin, mixinDevice } from '@/utils/mixin.js'
+import moment from 'moment'
+import CategoryTree from './CategoryTree'
+import CategorySelectTree from './CategorySelectTree'
+import TagSelect from './TagSelect'
+import { mapGetters } from 'vuex'
+import categoryApi from '@/api/category'
+import postApi from '@/api/post'
+import themeApi from '@/api/theme'
+export default {
+  name: 'BatchOperationDrawer',
+  mixins: [mixin, mixinDevice],
+  components: {
+    CategoryTree,
+    CategorySelectTree,
+    TagSelect
+  },
+  data() {
+    return {
+      categoryFormVisible: false,
+      settingLoading: true,
+      selectedPostIds: this.postIds,
+      categories: [],
+      categoryToCreate: {},
+      disallowComment: null,
+      topPriority: null,
+      selectedCategoryIds: [],
+      selectedTagIds: [],
+    }
+  },
+  props: {
+    postIds: {
+      type: Array,
+      required: true
+    },
+    visible: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  watch: {
+    visible(newValue, oldValue) {
+      if (newValue) {
+        this.loadSkeleton()
+        this.loadCategories()
+      }
+    }
+  },
+  methods: {
+    loadSkeleton() {
+      this.settingLoading = true
+      setTimeout(() => {
+        this.settingLoading = false
+      }, 500)
+    },
+    loadCategories() {
+      categoryApi.listAll().then(response => {
+        this.categories = response.data.data
+      })
+    },
+    handlerCreateCategory() {
+      if (!this.categoryToCreate.name) {
+        this.$notification['error']({
+          message: '提示',
+          description: '分类名称不能为空！'
+        })
+        return
+      }
+      categoryApi.create(this.categoryToCreate).then(response => {
+        this.loadCategories()
+        this.categoryToCreate = {}
+        this.toggleCategoryForm()
+      })
+    },
+    handleSaveSettings() {
+      console.log(this.disallowComment)
+      console.log(this.topPriority)
+      console.log(this.selectedTagIds)
+      console.log(this.selectedCategoryIds)
+      console.log("SAVE")
+    },
+    toggleCategoryForm() {
+      this.categoryFormVisible = !this.categoryFormVisible
+    },
+    onClose() {
+      this.$emit('close', false)
+    }
+  }
+}
+</script>

--- a/src/views/post/components/BatchOperationDrawer.vue
+++ b/src/views/post/components/BatchOperationDrawer.vue
@@ -298,6 +298,9 @@ export default {
     },
     toggleCategoryForm() {
       this.categoryFormVisible = !this.categoryFormVisible
+    },
+    onClose() {
+      this.$emit('close')
     }
   }
 }

--- a/src/views/post/components/BatchOperationDrawer.vue
+++ b/src/views/post/components/BatchOperationDrawer.vue
@@ -286,7 +286,7 @@ export default {
 
           this.$message.success('批量操作成功！')
 
-          this.$router.push({ name: 'PostList' })
+          this.$emit('close')
         })
         .finally(() => {
           this.saving = false
@@ -295,9 +295,6 @@ export default {
     },
     toggleCategoryForm() {
       this.categoryFormVisible = !this.categoryFormVisible
-    },
-    onClose() {
-      this.$emit('close', false)
     }
   }
 }

--- a/src/views/post/components/BatchOperationDrawer.vue
+++ b/src/views/post/components/BatchOperationDrawer.vue
@@ -218,6 +218,7 @@ export default {
   watch: {
     posts(val) {
       this.selectedPosts = val
+      // if all posts have the same setting, then display it
       const disallowCommentEqual =
         val.every((val, i, arr) => val.disallowComment === arr[0].disallowComment)
       const topPriorityEqual =
@@ -272,6 +273,8 @@ export default {
     },
     handleSaveSettings() {
       this.saving = true
+      // construct a param by the status of switch
+      // selectedTagIds is default to be null, but we need []
       const settingParams = {
         ids: this.selectedPostIds,
         disallowComment: this.disallowComment,

--- a/src/views/post/components/BatchOperationDrawer.vue
+++ b/src/views/post/components/BatchOperationDrawer.vue
@@ -16,7 +16,7 @@
       <div class="post-setting-drawer-content">
         <div :style="{ marginBottom: '16px' }">
           <h3 class="post-setting-drawer-title">基本设置</h3>
-          <br>
+          <br />
           <div class="post-setting-drawer-item">
             <a-form layout="vertical">
               <a-form-item label="开启评论：">
@@ -24,7 +24,7 @@
                   v-model="disallowComment"
                   :defaultValue="null"
                 >
-                  <a-radio :value="null">不改变</a-radio>
+                  <a-radio :value="null">不更变</a-radio>
                   <a-radio :value="false">开启</a-radio>
                   <a-radio :value="true">关闭</a-radio>
                 </a-radio-group>
@@ -34,7 +34,7 @@
                   v-model="topPriority"
                   :defaultValue="null"
                 >
-                  <a-radio :value="null">不改变</a-radio>
+                  <a-radio :value="null">不更变</a-radio>
                   <a-radio :value="1">是</a-radio>
                   <a-radio :value="0">否</a-radio>
                 </a-radio-group>
@@ -45,45 +45,57 @@
         <a-divider />
 
         <div :style="{ marginBottom: '16px' }">
-          <h3 class="post-setting-drawer-title">分类目录</h3>
+            <h3
+              class="post-setting-drawer-title"
+            >分类目录
+              <a-switch
+                checked-children="覆盖"
+                un-checked-children="不更变"
+                v-model="categorySwitch"
+                style="float: right;"/>
+            </h3>
           <div class="post-setting-drawer-item">
             <a-form layout="vertical">
               <a-form-item>
                 <category-tree
                   v-model="selectedCategoryIds"
+                  :disabled="!categorySwitch"
                   :categories="categories"
                 />
               </a-form-item>
-              <a-form-item v-if="categoryFormVisible">
+              <a-form-item v-if="categoryFormVisible && categorySwitch">
                 <category-select-tree
                   :categories="categories"
+                  v-model="categoryToCreate.parentId"
                 />
               </a-form-item>
-              <a-form-item v-if="categoryFormVisible">
+              <a-form-item v-if="categoryFormVisible && categorySwitch">
                 <a-input
                   placeholder="分类名称"
+                  v-model="categoryToCreate.name"
                 />
               </a-form-item>
-              <a-form-item v-if="categoryFormVisible">
+              <a-form-item v-if="categoryFormVisible && categorySwitch">
                 <a-input
                   placeholder="分类路径"
+                  v-model="categoryToCreate.slug"
                 />
               </a-form-item>
               <a-form-item>
                 <a-button
                   type="primary"
                   style="marginRight: 8px"
-                  v-if="categoryFormVisible"
+                  v-if="categoryFormVisible && categorySwitch"
                   @click="handlerCreateCategory"
                 >保存</a-button>
                 <a-button
                   type="dashed"
                   style="marginRight: 8px"
-                  v-if="!categoryFormVisible"
+                  v-if="!categoryFormVisible && categorySwitch"
                   @click="toggleCategoryForm"
                 >新增</a-button>
                 <a-button
-                  v-if="categoryFormVisible"
+                  v-if="categoryFormVisible && categorySwitch"
                   @click="toggleCategoryForm"
                 >取消</a-button>
               </a-form-item>
@@ -93,16 +105,50 @@
         <a-divider />
 
         <div :style="{ marginBottom: '16px' }">
-          <h3 class="post-setting-drawer-title">标签</h3>
+          <h3
+            class="post-setting-drawer-title"
+          >标签
+            <a-switch
+              checked-children="覆盖"
+              un-checked-children="不更变"
+              v-model="tagSwitch"
+              style="float: right;"/>
+          </h3>
           <div class="post-setting-drawer-item">
             <a-form layout="vertical">
               <a-form-item>
-                <TagSelect v-model="selectedTagIds" />
+                <TagSelect
+                  v-model="selectedTagIds"
+                  :disabled="!tagSwitch"
+                />
               </a-form-item>
             </a-form>
           </div>
         </div>
         <a-divider />
+
+        <div :style="{ marginBottom: '16px' }">
+          <h3
+            class="post-setting-drawer-title"
+          >加密设置
+            <a-switch
+              checked-children="覆盖"
+              un-checked-children="不更变"
+              v-model="passwordSwitch"
+              style="float: right;"/>
+          </h3>
+          <div class="post-setting-drawer-item">
+            <a-form layout="vertical">
+              <a-form-item label="访问密码：">
+                <a-input-password
+                  :disabled="!passwordSwitch"
+                  v-model="password"
+                  autocomplete="new-password"
+                />
+              </a-form-item>
+            </a-form>
+          </div>
+        </div>
 
         <a-divider class="divider-transparent" />
       </div>
@@ -139,6 +185,8 @@ export default {
     return {
       categoryFormVisible: false,
       settingLoading: true,
+      saving: false,
+      selectedPosts: this.posts,
       selectedPostIds: this.postIds,
       categories: [],
       categoryToCreate: {},
@@ -146,9 +194,17 @@ export default {
       topPriority: null,
       selectedCategoryIds: [],
       selectedTagIds: [],
+      password: "",
+      categorySwitch: false,
+      tagSwitch: false,
+      passwordSwitch: false
     }
   },
   props: {
+    posts: {
+      type: Array,
+      required: true
+    },
     postIds: {
       type: Array,
       required: true
@@ -160,6 +216,27 @@ export default {
     }
   },
   watch: {
+    posts(val) {
+      this.selectedPosts = val
+      const disallowCommentEqual =
+        val.every((val, i, arr) => val.disallowComment === arr[0].disallowComment)
+      const topPriorityEqual =
+        val.every((val, i, arr) => val.topPriority === arr[0].topPriority)
+      this.categorySwitch =
+        val.every((val, i, arr) => val.categoryIds.sort().toString() === arr[0].categoryIds.sort().toString())
+      this.tagSwitch =
+        val.every((val, i, arr) => val.tagIds.sort().toString() === arr[0].tagIds.sort().toString())
+      this.passwordSwitch =
+        val.every((val, i, arr) => val.password === arr[0].password)
+      this.disallowComment = disallowCommentEqual ? val[0].disallowComment : null
+      this.topPriority = topPriorityEqual ? val[0].topPriority : null
+      this.selectedCategoryIds = this.categorySwitch ? val[0].categoryIds : null
+      this.selectedTagIds = this.tagSwitch ? val[0].tagIds : null
+      this.password = this.passwordSwitch ? val[0].password : null
+    },
+    postIds(val) {
+      this.selectedPostIds = val
+    },
     visible(newValue, oldValue) {
       if (newValue) {
         this.loadSkeleton()
@@ -194,11 +271,27 @@ export default {
       })
     },
     handleSaveSettings() {
-      console.log(this.disallowComment)
-      console.log(this.topPriority)
-      console.log(this.selectedTagIds)
-      console.log(this.selectedCategoryIds)
-      console.log("SAVE")
+      this.saving = true
+      const settingParams = {
+        ids: this.selectedPostIds,
+        disallowComment: this.disallowComment,
+        topPriority: this.topPriority,
+        password: this.passwordSwitch ? this.password : null,
+        tagIds: this.tagSwitch ? (this.selectedTagIds == null ? [] : this.selectedTagIds) : null,
+        categoryIds: this.categorySwitch ? this.selectedCategoryIds : null
+      }
+      postApi.updataSettingInBatch(settingParams)
+        .then(response => {
+          this.$log.debug('Updated post', response.data.data)
+
+          this.$message.success('批量操作成功！')
+
+          this.$router.push({ name: 'PostList' })
+        })
+        .finally(() => {
+          this.saving = false
+          this.draftSaving = false
+        })
     },
     toggleCategoryForm() {
       this.categoryFormVisible = !this.categoryFormVisible

--- a/src/views/post/components/BatchOperationDrawer.vue
+++ b/src/views/post/components/BatchOperationDrawer.vue
@@ -45,15 +45,15 @@
         <a-divider />
 
         <div :style="{ marginBottom: '16px' }">
-            <h3
-              class="post-setting-drawer-title"
-            >分类目录
-              <a-switch
-                checked-children="覆盖"
-                un-checked-children="不更变"
-                v-model="categorySwitch"
-                style="float: right;"/>
-            </h3>
+          <h3
+            class="post-setting-drawer-title"
+          >分类目录
+            <a-switch
+              checked-children="覆盖"
+              un-checked-children="不更变"
+              v-model="categorySwitch"
+              style="float: right;"/>
+          </h3>
           <div class="post-setting-drawer-item">
             <a-form layout="vertical">
               <a-form-item>
@@ -165,14 +165,11 @@
 </template>
 <script>
 import { mixin, mixinDevice } from '@/utils/mixin.js'
-import moment from 'moment'
 import CategoryTree from './CategoryTree'
 import CategorySelectTree from './CategorySelectTree'
 import TagSelect from './TagSelect'
-import { mapGetters } from 'vuex'
 import categoryApi from '@/api/category'
 import postApi from '@/api/post'
-import themeApi from '@/api/theme'
 export default {
   name: 'BatchOperationDrawer',
   mixins: [mixin, mixinDevice],
@@ -194,7 +191,7 @@ export default {
       topPriority: null,
       selectedCategoryIds: [],
       selectedTagIds: [],
-      password: "",
+      password: '',
       categorySwitch: false,
       tagSwitch: false,
       passwordSwitch: false

--- a/src/views/post/components/CategoryTree.vue
+++ b/src/views/post/components/CategoryTree.vue
@@ -4,6 +4,7 @@
     :treeData="categoryTree"
     :defaultExpandAll="true"
     :checkedKeys="categoryIds"
+    :disabled="disabled"
     @check="onCheck"
   >
   </a-tree>
@@ -28,6 +29,11 @@ export default {
       type: Array,
       required: false,
       default: () => []
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   computed: {

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -514,8 +514,7 @@ export default {
               this.$message.success('文章更新成功！')
             }
 
-            this.$emit('onSaved', true)
-            this.$router.push({ name: 'PostList' })
+            this.$emit('close')
           })
           .finally(() => {
             this.saving = false
@@ -533,10 +532,8 @@ export default {
             } else {
               this.$message.success('文章发布成功！')
             }
-
-            this.$emit('onSaved', true)
-            this.$router.push({ name: 'PostList' })
             this.selectedPost = response.data.data
+            this.$emit('close')
           })
           .finally(() => {
             this.saving = false

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -513,8 +513,10 @@ export default {
             } else {
               this.$message.success('文章更新成功！')
             }
-
+            
+            // close drawer
             this.$emit('close')
+            // if in "posts/write" page then push
             if (this.saveDraftButton) {
               this.$router.push({ name: 'PostList' })
             }
@@ -536,7 +538,10 @@ export default {
               this.$message.success('文章发布成功！')
             }
             this.selectedPost = response.data.data
+            
+            // close drawer
             this.$emit('close')
+            // if in "posts/write" page then push
             if (this.saveDraftButton) {
               this.$router.push({ name: 'PostList' })
             }

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -514,12 +514,7 @@ export default {
               this.$message.success('文章更新成功！')
             }
 
-            // close drawer
-            this.$emit('close')
-            // if in "posts/write" page then push
-            if (this.saveDraftButton) {
-              this.$router.push({ name: 'PostList' })
-            }
+            this.closeAndJump()
           })
           .finally(() => {
             this.saving = false
@@ -538,13 +533,8 @@ export default {
               this.$message.success('文章发布成功！')
             }
             this.selectedPost = response.data.data
-
-            // close drawer
-            this.$emit('close')
-            // if in "posts/write" page then push
-            if (this.saveDraftButton) {
-              this.$router.push({ name: 'PostList' })
-            }
+            
+            this.closeAndJump()
           })
           .finally(() => {
             this.saving = false
@@ -575,6 +565,14 @@ export default {
         value: '',
         key: ''
       })
+    },
+    closeAndJump() {
+      // close drawer
+      this.$emit('close')
+      // if in "posts/write" page then push
+      if (this.saveDraftButton) {
+        this.$router.push({ name: 'PostList' })
+      }
     }
   }
 }

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -513,7 +513,7 @@ export default {
             } else {
               this.$message.success('文章更新成功！')
             }
-            
+
             // close drawer
             this.$emit('close')
             // if in "posts/write" page then push

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -515,6 +515,9 @@ export default {
             }
 
             this.$emit('close')
+            if (this.saveDraftButton) {
+              this.$router.push({ name: 'PostList' })
+            }
           })
           .finally(() => {
             this.saving = false
@@ -534,6 +537,9 @@ export default {
             }
             this.selectedPost = response.data.data
             this.$emit('close')
+            if (this.saveDraftButton) {
+              this.$router.push({ name: 'PostList' })
+            }
           })
           .finally(() => {
             this.saving = false

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -538,7 +538,7 @@ export default {
               this.$message.success('文章发布成功！')
             }
             this.selectedPost = response.data.data
-            
+
             // close drawer
             this.$emit('close')
             // if in "posts/write" page then push

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -533,7 +533,7 @@ export default {
               this.$message.success('文章发布成功！')
             }
             this.selectedPost = response.data.data
-            
+
             this.closeAndJump()
           })
           .finally(() => {

--- a/src/views/post/components/TagSelect.vue
+++ b/src/views/post/components/TagSelect.vue
@@ -6,6 +6,7 @@
       allowClear
       mode="tags"
       placeholder="选择或输入标签"
+      :disabled="disabled"
       @change="handleChange"
     >
       <a-select-option
@@ -32,6 +33,11 @@ export default {
       type: Array,
       required: false,
       default: () => []
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data() {


### PR DESCRIPTION
# Update
“所有文章”页面下的改动：
1. 分类目录支持树形结构
2. 文章状态和分类目录分别加入“所有文章”和”所有目录“的选项
3. 能够对已发布和私密的文章进行评论、置顶、分类、标签、加密的批量操作
4. 批量操作后提示成功

### 关于”更多操作“
用户能够对文章同时对评论、置顶、分类、标签、加密进行设置，若不需要设置则可选择不更变得radio和switch
如果选中的所有文章的某个设置的值相同，页面会显示原先的设置，以便用户在原来的设置基础上进行操作
实现方法：如果用户选择不更变，则传入值null，后台收到null不对该设置进行更新

### 发现的问题
对草稿箱和回收站的文章进行设置后，状态都会设为已发布，感觉有不妥

fix: [halo/issues/733](https://github.com/halo-dev/halo/issues/733)