### PR TITLE
发布文章时，slug给一个拼音默认值

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16048,6 +16048,11 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "tiny-pinyin": {
+      "version": "1.3.0",
+      "resolved": "http://nexus.yubang168.cn:8081/repository/npm-public/tiny-pinyin/-/tiny-pinyin-1.3.0.tgz",
+      "integrity": "sha1-Te51/7lv4kpEiHPx1Sxaa7wCaUY="
+    },
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "halo-editor": "^2.8.2",
     "marked": "^1.0.0",
     "moment": "^2.24.0",
+    "tiny-pinyin": "^1.3.0",
     "verte": "^0.0.12",
     "vue": "^2.6.11",
     "vue-clipboard2": "^0.3.0",

--- a/src/views/post/components/PostSettingDrawer.vue
+++ b/src/views/post/components/PostSettingDrawer.vue
@@ -31,7 +31,7 @@
                   <span v-else-if="options.post_permalink_type === 'DAY'">{{ options.blog_url }}{{ selectedPost.createTime?selectedPost.createTime:new Date() | moment_post_day }}{{ selectedPost.slug?selectedPost.slug:'${slug}' }}{{ (options.path_suffix?options.path_suffix:'') }}</span>
                   <span v-else-if="options.post_permalink_type === 'ID'">{{ options.blog_url }}/?p={{ selectedPost.id?selectedPost.id:'${id}' }}</span>
                 </template>
-                <a-input v-model="selectedPost.slug" />
+                <a-input v-model="selectedPost.slug" :defaultValue="slugDefaultValue"/>
               </a-form-item>
 
               <a-form-item label="发表时间：">
@@ -314,6 +314,7 @@ import { mapGetters } from 'vuex'
 import categoryApi from '@/api/category'
 import postApi from '@/api/post'
 import themeApi from '@/api/theme'
+import pinyin from 'tiny-pinyin'
 export default {
   name: 'PostSettingDrawer',
   mixins: [mixin, mixinDevice],
@@ -415,6 +416,16 @@ export default {
         return moment(date, 'YYYY-MM-DD HH:mm:ss')
       }
       return moment(new Date(), 'YYYY-MM-DD HH:mm:ss')
+    },
+    slugDefaultValue() {
+      if (this.selectedPost.title) {
+        if (pinyin.isSupported()) {
+          return pinyin.convertToPinyin(this.selectedPost.title, '-', true)
+        } else {
+          console.warn('当前浏览器不支持 tiny-pinin，请使用chrome等现代浏览器.')
+        }
+      }
+      return ''
     },
     ...mapGetters(['options'])
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,6 +7,16 @@ function resolve(dir) {
 
 // vue.config.js
 module.exports = {
+  // devServer: {
+  //   host: '0.0.0.0',
+  //   proxy: {
+  //     '/api/': {
+  //       'target': 'http://localhost:8090/',
+  //       changeOrigin: true,
+  //       ws: true
+  //     }
+  //   }
+  // },
   publicPath: process.env.PUBLIC_PATH,
   configureWebpack: {
     plugins: [


### PR DESCRIPTION
#121 
https://github.com/halo-dev/halo/issues/807
https://github.com/halo-dev/halo/issues/738

这个需求我也有，即自动生成一个拼音 slug，我已经实现，请 review。效果图：

![2020-05-23_22-43](https://www.topcoder.club/upload/2020/05/2020-05-23_22-43-8df309bcccd740e6915997f3b5e96f51.png)

大致思路是用 js 取得文章标题的中文拼音填入 slug，具体思路和调研过程见我下面的文章

https://www.topcoder.club/2020/05/halo-auto-fill-slug-when-publish-new-post

谢谢。