### PR TITLE
chore: disable automatic addition of assignees in pull requests

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,7 +2,7 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:


### PR DESCRIPTION
禁用在 pull requests 中自动指派人员。