### PR TITLE
fix: moving menu team causes submenus to be lost 

### DIFF
--- a/src/views/interface/components/MenuTreeNode.vue
+++ b/src/views/interface/components/MenuTreeNode.vue
@@ -143,8 +143,6 @@ export default {
       this.$set(item, 'formVisible', false)
     },
     async handleMoveMenu(item, team) {
-      console.log(item, team)
-
       const menu = deepClone(item)
       menu.team = team
       menu.parentId = 0

--- a/src/views/interface/components/MenuTreeNode.vue
+++ b/src/views/interface/components/MenuTreeNode.vue
@@ -46,11 +46,6 @@
                       >{{ team === '' ? '未分组' : team }}
                     </a-menu-item>
                   </a-sub-menu>
-                  <a-sub-menu title="复制到分组">
-                    <a-menu-item v-for="(team, index) in excludedTeams" :key="index" @click="handleCopyMenu(item, team)"
-                      >{{ team === '' ? '未分组' : team }}
-                    </a-menu-item>
-                  </a-sub-menu>
                 </a-menu>
               </a-dropdown>
             </template>
@@ -147,24 +142,34 @@ export default {
     handleCloseCreateMenuForm(item) {
       this.$set(item, 'formVisible', false)
     },
-    handleCopyMenu(item, team) {
+    async handleMoveMenu(item, team) {
+      console.log(item, team)
+
       const menu = deepClone(item)
       menu.team = team
       menu.parentId = 0
       menu.priority = 0
-      menu.id = null
-      apiClient.menu.create(menu).then(() => {
+
+      const toFlatList = data => {
+        if (!data || data.length === 0) return []
+
+        return data.reduce((prev, current) => {
+          const children = current.children.length > 0 ? toFlatList(current.children) : []
+          current.team = team
+          return [...prev, current, ...children]
+        }, [])
+      }
+
+      const flatList = [menu, ...toFlatList(menu.children)]
+
+      this.$log.debug('menu list as flat list:', flatList)
+
+      try {
+        await apiClient.menu.updateInBatch(flatList)
         this.$emit('reload')
-      })
-    },
-    handleMoveMenu(item, team) {
-      const menu = deepClone(item)
-      menu.team = team
-      menu.parentId = 0
-      menu.priority = 0
-      apiClient.menu.update(menu.id, menu).then(() => {
-        this.$emit('reload')
-      })
+      } catch (e) {
+        this.$log.error('Fail to update menu in batch', e)
+      }
     },
     onReloadEmit() {
       this.$emit('reload')


### PR DESCRIPTION
1. 修复移动菜单项到其他分组的时候，导致子菜单丢失的问题。
2. 暂时移除复制到其他分组的功能，暂时没办法解决子菜单关联的问题。

Close #363
