### PR TITLE
refactor: remove the button to remove the thumbnail from the post settings

### DIFF
--- a/src/views/post/components/PostSettingModal.vue
+++ b/src/views/post/components/PostSettingModal.vue
@@ -88,8 +88,11 @@
                     class="img"
                     @click="attachmentSelectVisible = true"
                   />
-                  <a-input v-model="form.model.thumbnail" placeholder="点击封面图选择图片，或者输入外部链接"></a-input>
-                  <a-button type="dashed" @click="form.model.thumbnail = null">移除</a-button>
+                  <a-input
+                    v-model="form.model.thumbnail"
+                    allow-clear
+                    placeholder="点击封面图选择图片，或者输入外部链接"
+                  ></a-input>
                 </a-space>
               </div>
             </a-form-item>
@@ -122,7 +125,7 @@
     </div>
     <template slot="footer">
       <slot name="extraFooter" />
-      <a-button :disabled="loading" @click="modalVisible = false"> 关闭 </a-button>
+      <a-button :disabled="loading" @click="modalVisible = false"> 关闭</a-button>
       <ReactiveButton
         v-if="!form.model.id"
         :errored="form.draftSaveErrored"

--- a/src/views/sheet/components/SheetSettingModal.vue
+++ b/src/views/sheet/components/SheetSettingModal.vue
@@ -76,8 +76,11 @@
                     class="img"
                     @click="attachmentSelectVisible = true"
                   />
-                  <a-input v-model="form.model.thumbnail" placeholder="点击封面图选择图片，或者输入外部链接"></a-input>
-                  <a-button type="dashed" @click="form.model.thumbnail = null">移除</a-button>
+                  <a-input
+                    v-model="form.model.thumbnail"
+                    allow-clear
+                    placeholder="点击封面图选择图片，或者输入外部链接"
+                  ></a-input>
                 </a-space>
               </div>
             </a-form-item>
@@ -110,7 +113,7 @@
     </div>
     <template slot="footer">
       <slot name="extraFooter" />
-      <a-button :disabled="loading" @click="modalVisible = false"> 关闭 </a-button>
+      <a-button :disabled="loading" @click="modalVisible = false"> 关闭</a-button>
       <ReactiveButton
         v-if="!form.model.id"
         :errored="form.draftSaveErrored"
@@ -149,6 +152,7 @@ import pinyin from 'tiny-pinyin'
 import { mapGetters } from 'vuex'
 // apis
 import apiClient from '@/utils/api-client'
+
 export default {
   name: 'SheetSettingModal',
   mixins: [mixin, mixinDevice],


### PR DESCRIPTION
|before|after |
| ---- | ---- |
|![image](https://user-images.githubusercontent.com/21301288/151551947-74337ce9-d196-46cb-87cd-6a9a61421a07.png)|![image](https://user-images.githubusercontent.com/21301288/151551822-350af456-9801-40e5-84b3-0187f9484267.png)|

移除按钮不是很有必要，可以用输入框的 clear 图标代替。

Signed-off-by: Ryan Wang <i@ryanc.cc>