### PR TITLE
refactor: post editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "filepond-plugin-file-validate-type": "^1.2.6",
     "filepond-plugin-image-preview": "^4.6.10",
     "halo-editor": "^2.8.4",
+    "lodash.debounce": "^4.0.8",
     "marked": "^4.0.10",
     "md5.js": "^1.3.5",
     "nprogress": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ specifiers:
   less: ^3.13.1
   less-loader: ^5.0.0
   lint-staged: ^11.2.6
+  lodash.debounce: ^4.0.8
   marked: ^4.0.10
   md5.js: ^1.3.5
   nprogress: ^0.2.0
@@ -58,6 +59,7 @@ dependencies:
   filepond-plugin-file-validate-type: 1.2.6_filepond@4.30.3
   filepond-plugin-image-preview: 4.6.10_filepond@4.30.3
   halo-editor: 2.8.4
+  lodash.debounce: 4.0.8
   marked: 4.0.10
   md5.js: 1.3.5
   nprogress: 0.2.0
@@ -5112,7 +5114,6 @@ packages:
 
   /lodash.debounce/4.0.8:
     resolution: {integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=}
-    dev: true
 
   /lodash.defaultsdeep/4.6.1:
     resolution: {integrity: sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==}

--- a/src/views/post/PostEdit.vue
+++ b/src/views/post/PostEdit.vue
@@ -107,6 +107,7 @@ export default {
         // Update the post content
         try {
           await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
+          this.postToStage.isInProcess = true
           this.handleRestoreSavedStatus()
           this.$message.success({
             content: '内容已保存',
@@ -148,6 +149,7 @@ export default {
       if (this.postToStage.id) {
         // Update the post content
         await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
+        this.postToStage.isInProcess = true
       } else {
         await this.handleCreatePost()
       }

--- a/src/views/post/PostEdit.vue
+++ b/src/views/post/PostEdit.vue
@@ -1,7 +1,7 @@
 <template>
   <page-view
     :title="postToStage.title ? postToStage.title : '新文章'"
-    :sub-title="postToStage.isInProcess && '当前内容已保存，但还未发布。'"
+    :sub-title="postToStage.isInProcess ? '当前内容已保存，但还未发布。' : ''"
     affix
   >
     <template slot="extra">

--- a/src/views/post/PostEdit.vue
+++ b/src/views/post/PostEdit.vue
@@ -43,6 +43,7 @@ import { PageView } from '@/layouts'
 import { mixin, mixinDevice, mixinPostEdit } from '@/mixins/mixin.js'
 import { datetimeFormat } from '@/utils/datetime'
 import apiClient from '@/utils/api-client'
+import debounce from 'lodash.debounce'
 
 export default {
   mixins: [mixin, mixinDevice, mixinPostEdit],
@@ -101,7 +102,7 @@ export default {
     }
   },
   methods: {
-    async handleSaveDraft() {
+    handleSaveDraft: debounce(async function () {
       if (this.postToStage.id) {
         // Update the post content
         try {
@@ -113,7 +114,7 @@ export default {
       } else {
         await this.handleCreatePost()
       }
-    },
+    }, 300),
 
     async handleCreatePost() {
       if (!this.postToStage.title) {

--- a/src/views/post/PostEdit.vue
+++ b/src/views/post/PostEdit.vue
@@ -1,7 +1,7 @@
 <template>
   <page-view
     :title="postToStage.title ? postToStage.title : '新文章'"
-    :sub-title="postToStage.isInProcess ? '当前内容已保存，但还未发布。' : ''"
+    :sub-title="postToStage.inProgress ? '当前内容已保存，但还未发布。' : ''"
     affix
   >
     <template slot="extra">
@@ -107,7 +107,7 @@ export default {
         // Update the post content
         try {
           const { data } = await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
-          this.postToStage.isInProcess = data.isInProcess
+          this.postToStage.inProgress = data.inProgress
           this.handleRestoreSavedStatus()
           this.$message.success({
             content: '内容已保存',
@@ -149,7 +149,7 @@ export default {
       if (this.postToStage.id) {
         // Update the post content
         const { data } = await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
-        this.postToStage.isInProcess = data.isInProcess
+        this.postToStage.inProgress = data.inProgress
       } else {
         await this.handleCreatePost()
       }

--- a/src/views/post/PostEdit.vue
+++ b/src/views/post/PostEdit.vue
@@ -106,8 +106,8 @@ export default {
       if (this.postToStage.id) {
         // Update the post content
         try {
-          await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
-          this.postToStage.isInProcess = true
+          const { data } = await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
+          this.postToStage.isInProcess = data.isInProcess
           this.handleRestoreSavedStatus()
           this.$message.success({
             content: '内容已保存',
@@ -148,8 +148,8 @@ export default {
       this.previewSaving = true
       if (this.postToStage.id) {
         // Update the post content
-        await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
-        this.postToStage.isInProcess = true
+        const { data } = await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
+        this.postToStage.isInProcess = data.isInProcess
       } else {
         await this.handleCreatePost()
       }

--- a/src/views/post/PostEdit.vue
+++ b/src/views/post/PostEdit.vue
@@ -1,5 +1,9 @@
 <template>
-  <page-view :title="postToStage.title ? postToStage.title : '新文章'" affix>
+  <page-view
+    :title="postToStage.title ? postToStage.title : '新文章'"
+    :sub-title="postToStage.isInProcess && '当前内容已保存，但还未发布。'"
+    affix
+  >
     <template slot="extra">
       <a-space>
         <a-button :loading="previewSaving" @click="handlePreviewClick">预览</a-button>
@@ -8,9 +12,6 @@
     </template>
     <a-row :gutter="12">
       <a-col :span="24">
-        <div v-show="postToStage.isInProcess && !isCreateMode" class="mb-4">
-          <a-alert message="当前内容已保存，但还未发布。" banner closable />
-        </div>
         <div class="mb-4">
           <a-input v-model="postToStage.title" placeholder="请输入文章标题" size="large" />
         </div>
@@ -57,8 +58,7 @@ export default {
       postSettingVisible: false,
       postToStage: {},
       contentChanges: 0,
-      previewSaving: false,
-      isCreateMode: false
+      previewSaving: false
     }
   },
   beforeRouteEnter(to, from, next) {
@@ -108,6 +108,10 @@ export default {
         try {
           await apiClient.post.updateDraftById(this.postToStage.id, this.postToStage.originalContent)
           this.handleRestoreSavedStatus()
+          this.$message.success({
+            content: '内容已保存',
+            duration: 0.5
+          })
         } catch (e) {
           this.$log.error('Failed to update post content', e)
         }
@@ -130,8 +134,10 @@ export default {
         const path = this.$router.history.current.path
         this.$router.push({ path, query: { postId: this.postToStage.id } }).catch(err => err)
 
-        // create mode does not need show alert
-        this.isCreateMode = true
+        this.$message.success({
+          content: '文章已创建',
+          duration: 0.5
+        })
       } catch (e) {
         this.$log.error('Failed to create post', e)
       }

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -243,6 +243,15 @@
               twoToneColor="red"
               type="pushpin"
             />
+            <a-tooltip v-if="record.isInProcess" title="当前有内容已保存，但还未发布。" placement="top">
+              <a-icon
+                class="cursor-pointer"
+                style="margin-right: 3px"
+                theme="twoTone"
+                twoToneColor="#52c41a"
+                type="info-circle"
+              />
+            </a-tooltip>
             <a-tooltip
               v-if="['PUBLISHED', 'INTIMATE'].includes(record.status)"
               :title="'点击访问【' + text + '】'"
@@ -411,7 +420,7 @@ const columns = [
   {
     title: '标题',
     dataIndex: 'title',
-    width: '150px',
+    width: '200px',
     ellipsis: true,
     scopedSlots: { customRender: 'postTitle' }
   },

--- a/src/views/post/PostList.vue
+++ b/src/views/post/PostList.vue
@@ -243,7 +243,7 @@
               twoToneColor="red"
               type="pushpin"
             />
-            <a-tooltip v-if="record.isInProcess" title="当前有内容已保存，但还未发布。" placement="top">
+            <a-tooltip v-if="record.inProgress" title="当前有内容已保存，但还未发布。" placement="top">
               <a-icon
                 class="cursor-pointer"
                 style="margin-right: 3px"


### PR DESCRIPTION
#438 

1. 取消保存草稿的按钮，后续改为在文章设置中提供选项。
2. 支持显示当前是否有未发布内容的特性。
3. 优化预览功能。

依赖于 https://github.com/halo-dev/halo/pull/1617 ，需要等待此 PR 合并。

Signed-off-by: Ryan Wang <i@ryanc.cc>