### PR TITLE
refactor: sheet editing

### DIFF
--- a/src/views/sheet/SheetEdit.vue
+++ b/src/views/sheet/SheetEdit.vue
@@ -36,12 +36,16 @@
 </template>
 
 <script>
-import { mixin, mixinDevice, mixinPostEdit } from '@/mixins/mixin.js'
-import { datetimeFormat } from '@/utils/datetime'
+// components
 import { PageView } from '@/layouts'
 import SheetSettingModal from './components/SheetSettingModal'
 import MarkdownEditor from '@/components/Editor/MarkdownEditor'
+
+// libs
+import { mixin, mixinDevice, mixinPostEdit } from '@/mixins/mixin.js'
+import { datetimeFormat } from '@/utils/datetime'
 import apiClient from '@/utils/api-client'
+import debounce from 'lodash.debounce'
 
 export default {
   components: {
@@ -100,7 +104,7 @@ export default {
     }
   },
   methods: {
-    async handleSaveDraft() {
+    handleSaveDraft: debounce(async function () {
       if (this.sheetToStage.id) {
         try {
           const { data } = await apiClient.sheet.updateDraftById(
@@ -119,7 +123,7 @@ export default {
       } else {
         await this.handleCreateSheet()
       }
-    },
+    }, 300),
 
     async handleCreateSheet() {
       if (!this.sheetToStage.title) {

--- a/src/views/sheet/components/CustomSheetList.vue
+++ b/src/views/sheet/components/CustomSheetList.vue
@@ -107,6 +107,15 @@
       :scrollToFirstRowOnChange="true"
     >
       <template #sheetTitle="text, record">
+        <a-tooltip v-if="record.inProgress" title="当前有内容已保存，但还未发布。" placement="top">
+          <a-icon
+            class="cursor-pointer"
+            style="margin-right: 3px"
+            theme="twoTone"
+            twoToneColor="#52c41a"
+            type="info-circle"
+          />
+        </a-tooltip>
         <a-tooltip v-if="record.status === 'PUBLISHED'" :title="'点击访问【' + text + '】'" placement="top">
           <a :href="record.fullPath" class="no-underline" target="_blank">
             {{ text }}


### PR DESCRIPTION
#438 

1. 取消保存草稿的按钮，后续改为在页面设置中提供选项。
2. 支持显示当前是否有未发布内容的特性。
3. 优化预览功能。

依赖于 https://github.com/halo-dev/halo/pull/1617 ，需要等待此 PR 合并。

Signed-off-by: Ryan Wang <i@ryanc.cc>