### PR TITLE
perf: optimize the PostSettingModel component style

### DIFF
--- a/src/views/post/components/PostSettingModal.vue
+++ b/src/views/post/components/PostSettingModal.vue
@@ -80,21 +80,20 @@
               <a-input-password v-model="form.model.password" autocomplete="new-password" />
             </a-form-item>
             <a-form-item label="封面图：">
-              <div class="post-thumb">
-                <a-space direction="vertical">
-                  <img
-                    :src="form.model.thumbnail || '/images/placeholder.jpg'"
-                    alt="Post cover thumbnail"
-                    class="img"
-                    @click="attachmentSelectVisible = true"
-                  />
-                  <a-input
-                    v-model="form.model.thumbnail"
-                    allow-clear
-                    placeholder="点击封面图选择图片，或者输入外部链接"
-                  ></a-input>
-                </a-space>
-              </div>
+              <a-space direction="vertical">
+                <img
+                  :src="form.model.thumbnail || '/images/placeholder.jpg'"
+                  alt="Post cover thumbnail"
+                  class="w-1/2 cursor-pointer"
+                  style="border-radius: 4px"
+                  @click="attachmentSelectVisible = true"
+                />
+                <a-input
+                  v-model="form.model.thumbnail"
+                  allow-clear
+                  placeholder="点击封面图选择图片，或者输入外部链接"
+                ></a-input>
+              </a-space>
             </a-form-item>
           </a-form>
         </a-tab-pane>
@@ -125,7 +124,6 @@
     </div>
     <template slot="footer">
       <slot name="extraFooter" />
-      <a-button :disabled="loading" @click="modalVisible = false"> 关闭</a-button>
       <ReactiveButton
         v-if="!form.model.id"
         :errored="form.draftSaveErrored"
@@ -146,6 +144,7 @@
         @callback="handleSavedCallback"
         @click="handleCreateOrUpdate()"
       ></ReactiveButton>
+      <a-button :disabled="loading" @click="modalVisible = false">关闭</a-button>
     </template>
     <AttachmentSelectModal
       :multiSelect="false"


### PR DESCRIPTION
before: 

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/155692260-647ea4b3-ecf3-4e7a-86e3-6d28d9c88870.png">


after:

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/155692122-128430ec-c00a-418b-8302-940d46db1308.png">

1. 缩小缩略图预览。
2. 保存和关闭按钮交换位置。


Signed-off-by: Ryan Wang <i@ryanc.cc>