### PR TITLE
fix: attachment list can't to display images with space path

### DIFF
--- a/src/components/Attachment/AttachmentSelectModal.vue
+++ b/src/components/Attachment/AttachmentSelectModal.vue
@@ -72,7 +72,7 @@
               <span v-if="!isImage(item)" class="attachments-group-item-type">{{ item.suffix }}</span>
               <span
                 v-else
-                :style="`background-image:url(${item.thumbPath})`"
+                :style="`background-image:url(${encodeURI(item.thumbPath)})`"
                 class="attachments-group-item-img"
                 loading="lazy"
               />

--- a/src/views/attachment/AttachmentList.vue
+++ b/src/views/attachment/AttachmentList.vue
@@ -85,7 +85,7 @@
                   <span v-if="!isImage(item)" class="attachments-group-item-type">{{ item.suffix }}</span>
                   <span
                     v-else
-                    :style="`background-image:url(${item.thumbPath})`"
+                    :style="`background-image:url(${encodeURI(item.thumbPath)})`"
                     class="attachments-group-item-img"
                     loading="lazy"
                   />


### PR DESCRIPTION
修复附件列表无法显示带空格地址图片的问题。

Signed-off-by: Ryan Wang <i@ryanc.cc>