### PR TITLE
fix: clear the verification result when editing the category directory.

### DIFF
--- a/src/views/post/CategoryList.vue
+++ b/src/views/post/CategoryList.vue
@@ -176,6 +176,7 @@ export default {
     async handleEdit(category) {
       try {
         const { data } = await apiClient.category.get(category.id)
+        this.$refs.categoryForm.clearValidate()
         this.form.model = data
 
         this.$refs.nameInput.focus()


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/70258597/157611039-1692d502-67ed-4bfd-9137-6bd1c0ff4701.gif)

after:
![after](https://user-images.githubusercontent.com/70258597/157611387-18d95f44-45cf-4660-ab73-6e160a8c2345.gif)

