### PR TITLE
feat: update avatar support to modify the avatar link

### DIFF
--- a/src/components/Input/AttachmentInput.vue
+++ b/src/components/Input/AttachmentInput.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <a-input :defaultValue="defaultValue" :placeholder="placeholder" :value="value" @change="onInputChange">
+    <a-input
+      ref="attachmentInput"
+      :defaultValue="defaultValue"
+      :placeholder="placeholder"
+      :value="value"
+      @change="onInputChange"
+    >
       <template #addonAfter>
         <a-button class="!p-0 !h-auto" type="link" @click="attachmentModalVisible = true">
           <a-icon type="picture" />
@@ -48,6 +54,9 @@ export default {
       if (raw.length) {
         this.$emit('input', encodeURI(raw[0].path))
       }
+    },
+    focus() {
+      this.$refs.attachmentInput.focus()
     }
   }
 }


### PR DESCRIPTION
个人资料的头像支持输入链接来修改。在 1.5.0 重构附件选择的时候丢失了设置 Gravatar 头像的功能，现使用此 PR 代替。

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/157804537-5699a132-54da-4082-bce4-051e45f8858b.png">

Signed-off-by: Ryan Wang <i@ryanc.cc>