### PR TITLE
chore: create OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+- ruibaby
+- guqing
+- JohnNiang
+- lan-yonghui
+- wangzhen-fit2cloud
+
+approvers:
+- ruibaby
+- guqing
+- JohnNiang

--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ reviewers:
 - JohnNiang
 - lan-yonghui
 - wangzhen-fit2cloud
+- QuentinHsu
 
 approvers:
 - ruibaby


### PR DESCRIPTION
The OWNERS file is for prow only. See https://www.kubernetes.dev/docs/guide/owners/ for more.

Signed-off-by: Ryan Wang <i@ryanc.cc>