### PR TITLE
fix: deep sub-categories not showing has password status

### DIFF
--- a/src/views/post/CategoryList.vue
+++ b/src/views/post/CategoryList.vue
@@ -154,22 +154,23 @@ export default {
       categories.forEach(category => (hashMap[category.id] = { ...category, children: [] }))
       categories.forEach(category => {
         const current = hashMap[category.id]
-        const parent = hashMap[category.parentId]
-
-        if (current.password) {
-          current.hasPassword = true
-        }
-
-        if (parent && (parent.password || parent.hasPassword)) {
-          current.hasPassword = true
-        }
-
         if (category.parentId) {
           hashMap[category.parentId].children.push(current)
         } else {
           treeData.push(current)
         }
       })
+
+      // set hasPassword field for tree node
+      const setHasPasswordField = (categories, hasPassword = false) => {
+        categories.forEach(category => {
+          category.hasPassword = !!category.password || hasPassword
+          if (category.children && category.children.length) {
+            setHasPasswordField(category.children, category.hasPassword)
+          }
+        })
+      }
+      setHasPasswordField(treeData)
       return treeData
     },
 


### PR DESCRIPTION
修复当父分类为加密状态时，超过第二级子分类没有显示加密状态的问题。

before:

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/21301288/160632252-5668ec7d-ed98-4103-9d49-b14890a26197.png">


after: 

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/21301288/160632353-75f8f128-337e-482f-8145-3c177359125b.png">

> 此时的 donet 分类为加密。

/kind bug

/cc @halo-dev/sig-halo-admin 

/milestone 1.5.x


Signed-off-by: Ryan Wang <i@ryanc.cc>