### PR TITLE
fix: recycle post title cannot be displayed in full

### DIFF
--- a/src/components/Post/PostListView.vue
+++ b/src/components/Post/PostListView.vue
@@ -209,9 +209,9 @@
                         {{ item.title }}
                       </a>
                     </a-tooltip>
-                    <a-button v-else class="!p-0" disabled type="link">
+                    <a v-else class="no-underline" href="javascript:void(0);" disabled>
                       {{ item.title }}
-                    </a-button>
+                    </a>
                   </div>
                 </template>
               </a-list-item-meta>
@@ -285,9 +285,9 @@
                 {{ text }}
               </a>
             </a-tooltip>
-            <a-button v-else class="!p-0" disabled type="link">
+            <a v-else class="no-underline" href="javascript:void(0);" disabled>
               {{ text }}
-            </a-button>
+            </a>
           </template>
 
           <template #status="status">

--- a/src/views/sheet/components/CustomSheetList.vue
+++ b/src/views/sheet/components/CustomSheetList.vue
@@ -105,9 +105,9 @@
                   </a>
                 </a-tooltip>
 
-                <a-button v-else class="!p-0" disabled type="link">
+                <a v-else class="no-underline" href="javascript:void(0);" disabled>
                   {{ item.title }}
-                </a-button>
+                </a>
               </div>
             </template>
           </a-list-item-meta>
@@ -151,9 +151,9 @@
           </a>
         </a-tooltip>
 
-        <a-button v-else class="!p-0" disabled type="link">
+        <a v-else class="no-underline" href="javascript:void(0);" disabled>
           {{ text }}
-        </a-button>
+        </a>
       </template>
 
       <template #status="status">


### PR DESCRIPTION
before:

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/161916388-239b50ab-8dcd-4423-bedc-d9fa4de9a4f7.png">


after:
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/161916317-277b7095-3cbf-45a0-9daf-6fb724a018ca.png">

/kind bug
/cc @halo-dev/sig-halo-admin


Signed-off-by: Ryan Wang <i@ryanc.cc>