### PR TITLE
fix: no category in category management does not show empty tips

### DIFF
--- a/src/views/post/CategoryList.vue
+++ b/src/views/post/CategoryList.vue
@@ -66,6 +66,7 @@
             ></ReactiveButton>
           </template>
           <a-spin :spinning="list.loading">
+            <a-empty v-if="list.data.length === 0" />
             <CategoryTreeNode
               v-model="list.treeData"
               @edit="handleEdit"


### PR DESCRIPTION
before:

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/161923505-31a9afea-633c-4648-87c2-7f1859bb8f5f.png">


after:

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/21301288/161923467-36868449-d829-4640-8f80-0a41df8ba3f4.png">

/kind bug
/cc @halo-dev/sig-halo-admin 

Signed-off-by: Ryan Wang <i@ryanc.cc>