### PR TITLE
fix: routing loop entry after reinstallation

### DIFF
--- a/src/router/guard/permissionGuard.js
+++ b/src/router/guard/permissionGuard.js
@@ -20,6 +20,13 @@ router.beforeEach(async (to, from, next) => {
     await store.dispatch('fetchIsInstalled')
   }
 
+  // if it is not installed, empty the dirty data
+  if (!store.getters.isInstalled) {
+    await store.commit('SET_OPTIONS', undefined)
+    await store.commit('CLEAR_TOKEN')
+    await store.commit('SET_USER', {})
+  }
+
   if (!store.getters.isInstalled && to.name !== 'Install') {
     next({
       name: 'Install'


### PR DESCRIPTION
修复因为缓存数据，重新安装会出现循环进入 install 路由的问题。

fixes: halo-dev/halo#1877

/kind bug
/milestone 1.5.x
/cc @halo-dev/sig-halo-admin 
/cherrypick release-1.5

Signed-off-by: Ryan Wang <i@ryanc.cc>