### PR TITLE
Bump version to 1.6.0-SNAPSHOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo-admin",
-  "version": "1.5.2",
+  "version": "1.6.0-SNAPSHOT",
   "author": "halo-dev",
   "description": "Halo admin client.",
   "repository": {


### PR DESCRIPTION
### Why we need it?

Recently, we have decided to maintain 1.5.x release for a long time, we created a new branch called "release-1.5".

Now, our master/main branch is for preparing for next release "1.6.x".

I change the version to 1.6.0-SNAPSHOT to stand for feature development for 1.6.x.

/kind chore
/cc @halo-dev/sig-halo-admin 